### PR TITLE
Remoção do arquivo Giropops.txt da apresentação do Gitlab

### DIFF
--- a/giropops.txt
+++ b/giropops.txt
@@ -1,2 +1,0 @@
-Estamos ao vivo na Twitch mostrando como utilizar de maneira totalmente
-execelente o nosso git e o gitlab


### PR DESCRIPTION
Removendo o arquivo giropops.txt da apresentação do gitlab do repositório do Helm.